### PR TITLE
[#185040272] Pinne MarkupSafe / Jinja2 und Molecule update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,17 @@ jobs:
           - distro: ubuntu-20.04
             test_type: unit
             ansible_version: '>=2.9, <2.10'
+            ansible_compat_version: '<3'
             jinja2_version: '<3.1'
+            molecule_version: '<5'
             python_version: '3.8'
             experimental: false
           - distro: ubuntu-20.04
             test_type: unit
             ansible_version: '>=2.10, <2.11'
+            ansible_compat_version: '<3'
             jinja2_version: '<3.1'
+            molecule_version: '<5'
             python_version: '3.8'
             experimental: false
           - distro: ubuntu-20.04
@@ -70,7 +74,9 @@ jobs:
           distro: ${{ matrix.distro }}
           test_type: ${{ matrix.test_type }}
           ansible_version: ${{ matrix.ansible_version }}
+          ansible_compat_version: ${{ matrix.ansible_compat_version }}
           jinja2_version: ${{ matrix.jinja2_version }}
+          molecule_version: ${{ matrix.molecule_version }}
           python_version: ${{ matrix.python_version }}
 
   release:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
+# Specify a pip compatible version specifier
+# like "==2.8.*" or ">=2.8,<2.9". Empty string
+# installs the latest version.
+
 _ansible:
-  # Specify a pip compatible version specifier
-  # like "==2.8.*" or ">=2.8,<2.9". Empty string
-  # installs the latest version.
-  version: ""
+  ansible_version: ""
+  jinja2_version: ""
+  markupsafe_version: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,9 +16,10 @@
 - name: Install Ansible and dependencies via PIP
   pip:
     name:
-      - markupsafe
+      - "MarkupSafe{{ _ansible.markupsafe_version | default('') }}"
       - netaddr
       - boto
       - boto3
       - passlib
-      - "ansible{{ _ansible.version | default('') }}"
+      - "Jinja2{{ _ansible.jinja2_version | default('') }}"
+      - "ansible{{ _ansible.ansible_version | default('') }}"


### PR DESCRIPTION
- Ansible Compat Input wird für https://github.com/Rheinwerk/molecule/pull/2 verwendet